### PR TITLE
calibrationEDD can be run from the command line with a config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ __pycache__/
 .eggs/ 
 
 *.h5
+
+.vscode

--- a/README.md
+++ b/README.md
@@ -7,3 +7,15 @@ Strain/Stress analysis
 ```bash
 python -m pip install easistrain
 ```
+
+## EDD
+
+### Summary
+
+- Task 1 → calibrationEDD.py → calibration of the conversion from Channel → Energy
+- Task 2 → angleCalibEDD.py → calibration of the diffraction angle
+- Task 3 → fitEDD → fitting
+- Task 4 → coordTransformation.py → transformation of the coordinates from the gonio reference to the sample reference
+- Task 5 → regroupPoints.py → regroup all the points
+- Task 6 → preStraind0cstEDD.py → calculates the strain in the measurement direction
+- Task 7 → strainStressd0cstEDD → calculates the strain and stress tensors

--- a/easistrain/EDD/utils.py
+++ b/easistrain/EDD/utils.py
@@ -1,0 +1,6 @@
+import yaml
+
+
+def read_config_file(path: str):
+    with open(path, "r") as config_file:
+        return yaml.load(config_file, Loader=yaml.SafeLoader)

--- a/example_config/calibrationEDD.yml
+++ b/example_config/calibrationEDD.yml
@@ -1,0 +1,13 @@
+########### Example of the arguments of the main function #############
+fileRead: '/home/esrf/slim/data/ihme10/id15/align/ihme10_align.h5'
+fileSave: '/home/esrf/slim/easistrain/easistrain/EDD/Results_ihme10_align.h5'
+sample: 'align'
+dataset: '0001'
+scanNumberHorizontalDetector: '66'
+scanNumberVerticalDetector: '65'
+nameHorizontalDetector: 'mca2_det0'
+nameVerticalDetector: 'mca2_det1'
+numberOfBoxes: 4
+nbPeaksInBoxes: [1, 2, 1, 1]
+rangeFit: [620, 780, 1020, 1120, 3500, 3800, 3850, 4090]
+sourceCalibrantFile: '/home/esrf/slim/easistrain/easistrain/EDD/BaSource'

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,7 @@ install_requires =
     h5py
     numpy
     pyfai
+    pyyaml~=5.0
     scipy
     silx
 
@@ -36,3 +37,10 @@ dev =
     %(test)s
     black
     flake8
+
+[flake8]
+max-line-length = 88
+# E203, W503 disabled because incompatible with black formatting
+# E262 (inline should begin by #) ignored because of numerous ## comments
+# E501 (line too long) ignored because of the end-of-line comments
+extend-ignore = E203, E262, E501, W503


### PR DESCRIPTION
I run `calibrationEDD` a first time. For ease of use, it is now possible to run the file from the command line by supplying a YML configuration file.

I did some minor improvements underlined below.